### PR TITLE
33 🍃Sentry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,9 @@ val shadowDependencies = listOf(
      "com.mysql:mysql-connector-j:8.1.0",
      "com.zaxxer:HikariCP:5.0.1",
 
+    "io.sentry:sentry:6.31.0",
+    "io.sentry:sentry-kotlin-extensions:6.31.0",
+
 //    "io.ktor:ktor-client-core:$ktorVersion",
 //    "io.ktor:ktor-client-okhttp:$ktorVersion",
 //    "io.ktor:ktor-client-cio:$ktorVersion",

--- a/src/main/kotlin/de/coasterfreak/fantasyfrontiers/Start.kt
+++ b/src/main/kotlin/de/coasterfreak/fantasyfrontiers/Start.kt
@@ -2,6 +2,7 @@ package de.coasterfreak.fantasyfrontiers
 
 import de.coasterfreak.fantasyfrontiers.utils.DatabaseMigrator
 import de.coasterfreak.fantasyfrontiers.utils.TownImageGenerator
+import io.sentry.Sentry
 
 /**
  * The main entry point of the application.
@@ -9,6 +10,12 @@ import de.coasterfreak.fantasyfrontiers.utils.TownImageGenerator
  * @param args The command line arguments.
  */
 fun main(args: Array<String>) {
+    Sentry.init { options ->
+        options.dsn = "https://a848ccc3e9ffcb404ae6b5681ac419bb@sentry.flawcra.cc/29"
+        // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+        // We recommend adjusting this value in production.
+        options.tracesSampleRate = 1.0
+    }
 
     when (args.getOrNull(0)) {
         "migrate" -> DatabaseMigrator().migrate()


### PR DESCRIPTION
- Added `io.sentry:sentry:6.31.0` and `io.sentry:sentry-kotlin-extensions:6.31.0` as shadow dependencies in the build.gradle.kts file.
- Initialized Sentry in the main function of Start.kt with a DSN and set tracesSampleRate to 1.0 for capturing 100% of transactions for performance monitoring.

Note: The DSN used is a placeholder and should be replaced with the actual DSN in production.

closes #33 
